### PR TITLE
adjust zig and package versions

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,8 +1,8 @@
 .{
     .name = .small_array_list,
-    .version = "0.1.0",
+    .version = "0.1.1",
     .fingerprint = 0x378608764b63102b,
-    .minimum_zig_version = "0.14.1",
+    .minimum_zig_version = "0.14.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
Set the correct version in `build.zig.zon` and adjust the minimum zig version.