### PR TITLE
support writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ std.debug.print("len={} capacity={}\n", .{ list.len, list.capacity });
 First, add the dependency to your `build.zig.zon`:
 
 ```sh
-zig fetch --save git+https://github.com/kalamay/small-array-list#v0.1.1
+zig fetch --save git+https://github.com/kalamay/small-array-list#v0.2.0
 ```
 
 Next add the dependecy to your `build.zig`:
@@ -103,7 +103,7 @@ native machine word size. Because a zig slice requires two machine words for
 storing it's `ptr` and `len`, this space can be used for direct item storage
 instead until the small capacity is exceeded. For any given type `T`, the
 small array list can store up to `2*@sizeOf(usize) / @sizeOf(T)` items before
-requiring any internal allocation. 
+requiring any internal allocation.
 
 For example on a 64-bit processor will print out `smallCapacity=4 sizeOf=24`:
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .small_array_list,
-    .version = "0.1.1",
+    .version = "0.2.0",
     .fingerprint = 0x378608764b63102b,
     .minimum_zig_version = "0.14.0",
     .paths = .{

--- a/src/root.zig
+++ b/src/root.zig
@@ -644,6 +644,47 @@ pub fn SmallArrayListAlignedSized(comptime T: type, comptime alignment: ?u29, co
             self.as.slice = new_mem;
             self.capacity = new_capacity;
         }
+
+        pub const WriterContext = struct {
+            self: *Self,
+            allocator: Allocator,
+        };
+
+        pub const Writer = if (T != u8)
+            @compileError("The Writer interface is only defined for SmallArrayList(u8) " ++
+                "but the given type is SmallArrayList(" ++ @typeName(T) ++ ")")
+        else
+            std.io.Writer(WriterContext, Allocator.Error, appendWrite);
+
+        /// Initializes a Writer which will append to the list.
+        pub fn writer(self: *Self, gpa: Allocator) Writer {
+            return .{ .context = .{ .self = self, .allocator = gpa } };
+        }
+
+        /// Same as `append` except it returns the number of bytes written,
+        /// which is always the same as `m.len`. The purpose of this function
+        /// existing is to match `std.io.Writer` API.
+        /// Invalidates element pointers if additional memory is needed.
+        fn appendWrite(context: WriterContext, m: []const u8) Allocator.Error!usize {
+            try context.self.appendSlice(context.allocator, m);
+            return m.len;
+        }
+
+        pub const FixedWriter = std.io.Writer(*Self, Allocator.Error, appendWriteFixed);
+
+        /// Initializes a Writer which will append to the list but will return
+        /// `error.OutOfMemory` rather than increasing capacity.
+        pub fn fixedWriter(self: *Self) FixedWriter {
+            return .{ .context = self };
+        }
+
+        /// The purpose of this function existing is to match `std.io.Writer` API.
+        fn appendWriteFixed(self: *Self, m: []const u8) error{OutOfMemory}!usize {
+            const available_capacity = self.capacity - self.len;
+            if (m.len > available_capacity) return error.OutOfMemory;
+            self.appendSliceAssumeCapacity(m);
+            return m.len;
+        }
     };
 }
 
@@ -1179,4 +1220,31 @@ test "sized" {
 
     try testing.expect(list1.hasAllocation());
     try testing.expect(!list2.hasAllocation());
+}
+
+test "SmallArrayList(u8) implements writer" {
+    const a = testing.allocator;
+
+    {
+        var buffer: SmallArrayList(u8) = .empty;
+        defer buffer.deinit(a);
+
+        const x: i32 = 42;
+        const y: i32 = 1234;
+        try buffer.writer(a).print("x: {}\ny: {}\n", .{ x, y });
+
+        try testing.expectEqualSlices(u8, "x: 42\ny: 1234\n", buffer.items());
+    }
+    {
+        var list: SmallArrayListAligned(u8, 2) = .empty;
+        defer list.deinit(a);
+
+        const writer = list.writer(a);
+        try writer.writeAll("a");
+        try writer.writeAll("bc");
+        try writer.writeAll("d");
+        try writer.writeAll("efg");
+
+        try testing.expectEqualSlices(u8, "abcdefg", list.items());
+    }
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -120,11 +120,6 @@ pub fn SmallArrayListAlignedSized(comptime T: type, comptime alignment: ?u29, co
         pub const Slice = SliceType;
         pub const SliceConst = SliceConstType;
 
-        /// Initialized an empty SmallArrayList. Deinitialize with `deinit`.
-        pub fn init() Self {
-            return empty;
-        }
-
         /// Initialize with capacity to hold `num` elements.
         /// The resulting capacity will equal `num` exactly.
         /// Deinitialize with `deinit`.

--- a/src/root.zig
+++ b/src/root.zig
@@ -124,7 +124,7 @@ pub fn SmallArrayListAlignedSized(comptime T: type, comptime alignment: ?u29, co
         /// The resulting capacity will equal `num` exactly.
         /// Deinitialize with `deinit`.
         pub fn initCapacity(gpa: Allocator, num: usize) Allocator.Error!Self {
-            var self = Self{};
+            var self = Self.empty;
             try self.ensureTotalCapacityPrecise(gpa, num);
             return self;
         }


### PR DESCRIPTION
This change makes a few changes:

1. adds support for writers, both expanding and fixed
2. removed `.init` altogether in favor of `.empty`
3. added more tests